### PR TITLE
Enhance PixelPerfectFilter to update uniforms only when values change, improving performance and reducing unnecessary cpu to gpu updates.

### DIFF
--- a/scripts/PixelArtFilter.js
+++ b/scripts/PixelArtFilter.js
@@ -150,8 +150,13 @@ export class PixelPerfectFilter extends PIXI.Filter {
             return;
         }
         this.originalTexture = tex;
-        this.uniforms.uOriginalTexture = this.originalTexture;
-        spriteMesh.roundPixels = true;
+        // If the texture object has changed, update the uniforms
+        if (this.uniforms.uOriginalTexture !== this.originalTexture) {
+            this.uniforms.uOriginalTexture = this.originalTexture;
+        }
+        if (!spriteMesh.roundPixels) {
+            spriteMesh.roundPixels = true;
+        }
         this.targetSprite = spriteMesh;
     }
     /**
@@ -176,16 +181,26 @@ export class PixelPerfectFilter extends PIXI.Filter {
             return;
         }
         this.updateSpriteData(spriteMesh);
-        // Update the alpha uniform, from the placeable document
-        this.uniforms.uSpriteAlpha = placeable.document?.alpha;
+        const placeableAlpha = placeable.document?.alpha || 1.0;
+        // If the sprite alpha has changed, update the uniform
+        if (this.uniforms.uSpriteAlpha !== placeableAlpha) {
+            // Update the alpha uniform, from the placeable document
+            this.uniforms.uSpriteAlpha = placeableAlpha;
+        }
+        let newTint = null;
+        // update the tint color uniform, from the placeable document. default to white if not set
+        // Foundry v12 uses a different format for tint colors
         if (game.release && parseFloat(game.release.version) >= 12) {
-            // update the tint color uniform, from the placeable document. default to white if not set
-            this.uniforms.uSpriteTint = placeable.document?.texture?.tint?.rgb || [1, 1, 1];
+            newTint = placeable.document?.texture?.tint?.rgb || [1, 1, 1];
         }
         else {
             const tintHex = placeable.document?.texture?.tint || '#ffffff';
             // @ts-ignore
-            this.uniforms.uSpriteTint = hexToRgb(tintHex);
+            newTint = hexToRgb(tintHex);
+        }
+        // If the tint color has changed, update the uniform
+        if (newTint !== null && this.uniforms.uSpriteTint !== newTint) {
+            this.uniforms.uSpriteTint = newTint;
         }
     }
     /**
@@ -204,20 +219,16 @@ export class PixelPerfectFilter extends PIXI.Filter {
      */
     apply(filterManager, input, output, clear) {
         const texture = this.originalTexture;
-        if (texture.valid) {
-            if (!texture.uvMatrix)
-                texture.uvMatrix = new PIXI.TextureMatrix(texture, 0.0);
-            texture.uvMatrix.update();
+        if (!texture.uvMatrix)
+            texture.uvMatrix = new PIXI.TextureMatrix(texture, 0.0);
+        texture.uvMatrix.update();
+        if (this.uniforms.uOriginalTexture !== texture) {
             this.uniforms.uOriginalTexture = texture;
-            this.uniforms.uOriginalUVMatrix = filterManager
-                .calculateSpriteMatrix(this.originalUVMatrix, this.targetSprite)
-                .prepend(texture.uvMatrix.mapCoord);
-            this.uniforms.inputClampTarget = texture.uvMatrix.uClampFrame;
         }
-        else {
-            console.warn("pixel-perfect: Texture is not valid, skipping filter application.");
-            return;
-        }
+        this.uniforms.uOriginalUVMatrix = filterManager
+            .calculateSpriteMatrix(this.originalUVMatrix, this.targetSprite)
+            .prepend(texture.uvMatrix.mapCoord);
+        this.uniforms.inputClampTarget = texture.uvMatrix.uClampFrame;
         super.apply(filterManager, input, output, clear);
     }
     /**

--- a/scripts/module.js
+++ b/scripts/module.js
@@ -46,6 +46,7 @@ Hooks.on('canvasReady', async () => {
             pixelFilters.set(placeable.id, pixelFilter);
         }
         // Always update the filter's sprite/texture reference
+        // caching etc. is handled by the function itself
         pixelFilter.updatePlaceableData(placeable);
         // if filters is null, initialize it as an empty array
         if (!targetObj.filters)

--- a/scripts/module.ts
+++ b/scripts/module.ts
@@ -53,6 +53,7 @@ Hooks.on('canvasReady', async () => {
     }
 
     // Always update the filter's sprite/texture reference
+    // caching etc. is handled by the function itself
     pixelFilter.updatePlaceableData(placeable);
 
     // if filters is null, initialize it as an empty array


### PR DESCRIPTION
add guards to each uniform to compare for changes, only updating the uniform if it actually changes. 

closes #3